### PR TITLE
Discount links

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -37,4 +37,15 @@ class Invoice < ApplicationRecord
   def discounted_revenue
     invoice_items.sum {|ii| ii.discounted_ii_revenue}
   end
+
+  def invoice_discounts
+    discounts = []
+    invoice_items.each do |ii|
+      # require "pry"; binding.pry
+      if !ii.discounts_applied.nil?
+        discounts << ii.discounts_applied
+      end
+    end
+    discounts
+  end
 end

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -4,6 +4,12 @@
 <p>Date Created: <%= @invoice.created_at_formatted %></p>
 <p>Total Revenue: <%= number_to_currency(@invoice.total_revenue.fdiv(100)) %></p>
 <p>Revenue After Discounts: <%= number_to_currency(@invoice.discounted_revenue.fdiv(100)) %></p>
+<p>Discounts Applied:</p>
+<ul>
+  <% @invoice.invoice_discounts.each do |discount| %>
+    <li><%= link_to "#{discount.percentage}% off #{discount.threshold}", merchant_discount_path(@merchant, discount) %></li>
+  <% end %>
+</ul>
 <p>Customer Name: <%= @invoice.customer_by_id.first_name %> <%= @invoice.customer_by_id.last_name %></p>
 
 <table class="table table-hover">

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -67,8 +67,6 @@ describe 'admin invoices show page' do
   end
 
   it 'displays all items on invoice' do
-    save_and_open_page
-
     within("#table-#{@ii1.id}") do
       expect(page).to have_content(@item1.name)
       expect(page).to have_content(@ii1.quantity)

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Merchant Invoices Show page' do
   before(:each) do
     @merch1 = create(:merchant)
     @merch2 = create(:merchant)
-    @merch1.discounts.create!(threshold: 15, percentage: 10)
+    @disc1 = @merch1.discounts.create!(threshold: 15, percentage: 10)
     @cust1 = create(:customer)
     @cust2 = create(:customer)
     @cust3 = create(:customer)
@@ -117,5 +117,11 @@ RSpec.describe 'Merchant Invoices Show page' do
   it 'shows the total discounted revenue for the invoice discounted' do
       expect(page).to have_content("Revenue After Discounts:")
       expect(page).to have_content("$575.00")
+  end
+
+  it 'shows all the discounts applied to the invoice' do
+    expect(page).to have_link("10% off 15")
+    click_link("10% off 15")
+    expect(current_path).to eq(merchant_discount_path(@merch1, @disc1))
   end
 end


### PR DESCRIPTION
## What I did

- Remove save and open page from last round of development
- Write invoice instance method that returns an array of all discounts applied to the invoice
- For each discount applied to an invoice, add a link to that discounts show page on the invoice show page
- Feature testing to ensure the link is present and functional
- Still need to do more edge-case testing for the discounting of invoice items