### PR TITLE
Merchants invoice show

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -34,8 +34,24 @@ class Invoice < ApplicationRecord
     invoice_items.where(invoice_id: id).sum('quantity * unit_price')
   end
 
+  def merchants_revenue(merchant)
+    invoice_items.joins(item: :merchant)
+                 .where('items.merchant_id = ?', merchant.id)
+                 .sum('invoice_items.quantity * invoice_items.unit_price')
+  end
+
+  def merchants_invoice_items(merchant)
+    invoice_items.joins(item: :merchant)
+                 .where('items.merchant_id = ?', merchant.id)
+  end
+
+  def merchants_discounted_revenue(merchant)
+    merchants_iis = merchants_invoice_items(merchant)
+    merchants_iis.sum { |ii| ii.discounted_ii_revenue }
+  end
+
   def discounted_revenue
-    invoice_items.sum {|ii| ii.discounted_ii_revenue}
+    invoice_items.sum { |ii| ii.discounted_ii_revenue }
   end
 
   def invoice_discounts

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -1,8 +1,8 @@
 class InvoiceItem < ApplicationRecord
   belongs_to :item
   belongs_to :invoice
-  # has_many :merchants, through: :item
-  # has_many :discounts, through: :merchants
+  has_many :merchants, through: :item
+  has_many :discounts, through: :merchants
 
   enum status: {
     pending: 0,
@@ -11,8 +11,7 @@ class InvoiceItem < ApplicationRecord
   }
 
   def discounts_applied
-    item.merchant
-        .discounts
+        discounts
         .where("discounts.threshold <= ?", quantity)
         .order(:percentage)
         .last

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -26,7 +26,7 @@
       <tr>
         <td><%= invoice_item.item.name %></td>
         <td><%= invoice_item.quantity %></td>
-        <td><%= number_to_currency(@invoice.item_unit_price(invoice_item.item.id)) %></td>
+        <td><%= number_to_currency(@invoice.item_unit_price(invoice_item.item.id).fdiv(100)) %></td>
         <td><%= form_with model: invoice_item, local: true do |f| %>
               <%= f.hidden_field :merchant_id, value: invoice_item.item.merchant.id %>
               <%= f.hidden_field :invoice_id, value: @invoice.id %>

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -2,8 +2,8 @@
 
 <p>Status: <%= @invoice.status %></p>
 <p>Date Created: <%= @invoice.created_at_formatted %></p>
-<p>Total Revenue: <%= number_to_currency(@invoice.total_revenue.fdiv(100)) %></p>
-<p>Revenue After Discounts: <%= number_to_currency(@invoice.discounted_revenue.fdiv(100)) %></p>
+<p>Total Revenue: <%= number_to_currency(@invoice.merchants_revenue(@merchant).fdiv(100)) %></p>
+<p>Revenue After Discounts: <%= number_to_currency(@invoice.merchants_discounted_revenue(@merchant).fdiv(100)) %></p>
 <p>Discounts Applied:</p>
 <ul>
   <% @invoice.invoice_discounts.each do |discount| %>

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -68,8 +68,8 @@ RSpec.describe 'Merchant Invoices Show page' do
     expect(page).to have_content(@item3.name)
     expect(page).to have_content(@ii1.quantity)
     expect(page).to have_content(@ii2.quantity)
-    expect(page).to have_content('$1,000.00')
-    expect(page).to have_content('$4,000.00')
+    expect(page).to have_content('$10.00')
+    expect(page).to have_content('$40.00')
     expect(page).to have_content(@invoice1.item_status(@item1.id))
     expect(page).to have_content(@invoice1.item_status(@item2.id))
 

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Merchant Invoices Show page' do
     @cust7 = create(:customer)
     @item1 = create(:item, merchant: @merch1)
     @item2 = create(:item, merchant: @merch1)
-    @item3 = create(:item, merchant: @merch1)
+    @item3 = create(:item, merchant: @merch2)
     @item4 = create(:item, merchant: @merch2)
     @item5 = create(:item, merchant: @merch2)
     @item6 = create(:item, merchant: @merch2)
@@ -28,7 +28,7 @@ RSpec.describe 'Merchant Invoices Show page' do
     @invoice8 = create(:invoice, customer: @cust7)
     @ii1 = InvoiceItem.create(item: @item1, invoice: @invoice1, status: 1, quantity: 15, unit_price: 1000)
     @ii2 = InvoiceItem.create(item: @item2, invoice: @invoice1, status: 1, quantity: 11, unit_price: 4000)
-    InvoiceItem.create(item: @item3, invoice: @invoice2, status: 1)
+    InvoiceItem.create(item: @item3, invoice: @invoice1, status: 1, quantity: 15, unit_price: 1000)
     InvoiceItem.create(item: @item1, invoice: @invoice2)
     InvoiceItem.create(item: @item1, invoice: @invoice3)
     InvoiceItem.create(item: @item1, invoice: @invoice4)
@@ -65,6 +65,7 @@ RSpec.describe 'Merchant Invoices Show page' do
   it 'Shows all items on the invoice' do
     expect(page).to have_content(@item1.name)
     expect(page).to have_content(@item2.name)
+    expect(page).to have_content(@item3.name)
     expect(page).to have_content(@ii1.quantity)
     expect(page).to have_content(@ii2.quantity)
     expect(page).to have_content('$1,000.00')
@@ -72,13 +73,12 @@ RSpec.describe 'Merchant Invoices Show page' do
     expect(page).to have_content(@invoice1.item_status(@item1.id))
     expect(page).to have_content(@invoice1.item_status(@item2.id))
 
-    expect(page).to_not have_content(@item3.name)
     expect(page).to_not have_content(@item4.name)
     expect(page).to_not have_content(@item5.name)
     expect(page).to_not have_content(@item6.name)
   end
 
-  it 'shows total revenue' do
+  it 'shows revenue for the merchants items' do
     expect(page).to have_content('$590.00')
   end
 

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe InvoiceItem, type: :model do
   describe 'relationships' do
     it { should belong_to(:invoice) }
     it { should belong_to(:item) }
-    # it { should have_many(:merchants).through(:item) }
-    # it { should have_many(:discounts).through(:merchants) }
+    it { should have_many(:merchants).through(:item) }
+    it { should have_many(:discounts).through(:merchants) }
   end
 
   before :each do

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Invoice, type: :model do
 
   before(:each) do
     @merch1 = create(:merchant)
+    @merch2 = create(:merchant)
     @merch1.discounts.create!(threshold: 15, percentage: 10)
     @cust1 = create(:customer)
     @cust2 = create(:customer)
@@ -20,7 +21,7 @@ RSpec.describe Invoice, type: :model do
     @cust7 = create(:customer)
     @item1 = create(:item, merchant: @merch1)
     @item2 = create(:item, merchant: @merch1)
-    @item3 = create(:item, merchant: @merch1)
+    @item3 = create(:item, merchant: @merch2)
     @invoice1 = create(:invoice, customer: @cust1)
     @invoice2 = create(:invoice, customer: @cust2)
     @invoice3 = create(:invoice, customer: @cust3)
@@ -29,10 +30,10 @@ RSpec.describe Invoice, type: :model do
     @invoice6 = create(:invoice, customer: @cust6)
     @invoice7 = create(:invoice, customer: @cust7)
     @invoice8 = create(:invoice, customer: @cust7)
-    InvoiceItem.create(item: @item1, invoice: @invoice1, status: 1, quantity: 15, unit_price: 1000)
-    InvoiceItem.create(item: @item2, invoice: @invoice1, status: 1, quantity: 5, unit_price: 100)
-    InvoiceItem.create(item: @item3, invoice: @invoice1, status: 1, quantity: 5, unit_price: 100)
-    InvoiceItem.create(item: @item1, invoice: @invoice1, quantity: 5, unit_price: 100)
+    @ii1 = InvoiceItem.create(item: @item1, invoice: @invoice1, status: 1, quantity: 15, unit_price: 1000)
+    @ii2 = InvoiceItem.create(item: @item2, invoice: @invoice1, status: 1, quantity: 5, unit_price: 100)
+    @ii3 = InvoiceItem.create(item: @item3, invoice: @invoice1, status: 1, quantity: 5, unit_price: 100)
+    # InvoiceItem.create(item: @item1, invoice: @invoice1, quantity: 5, unit_price: 100)
     InvoiceItem.create(item: @item1, invoice: @invoice3, quantity: 5, unit_price: 100)
     InvoiceItem.create(item: @item1, invoice: @invoice4, quantity: 5, unit_price: 100)
     InvoiceItem.create(item: @item1, invoice: @invoice5, quantity: 5, unit_price: 100)
@@ -79,11 +80,24 @@ RSpec.describe Invoice, type: :model do
     end
 
     it '#total_revenue' do
-      expect(@invoice1.total_revenue).to eq(16500)
+      expect(@invoice1.total_revenue).to eq(16000)
+    end
+
+    it '#merchants_revenue' do
+      expect(@invoice1.merchants_revenue(@merch1)).to eq(15500)
     end
 
     it '#discounted_revenue' do
-      expect(@invoice1.discounted_revenue).to eq(15000)
+      expect(@invoice1.discounted_revenue).to eq(14500)
+    end
+
+    it '#merchants_invoice_items' do
+      expect(@invoice1.merchants_invoice_items(@merch1)).to eq([@ii1, @ii2])
+      expect(@invoice1.merchants_invoice_items(@merch2)).to eq([@ii3])
+    end
+
+    it '#merchants_discounted_revenue' do
+      expect(@invoice1.merchants_discounted_revenue(@merch1)).to eq(14000)
     end
 
     ## creating new merchants, invoices, etc. in each edge case test to ensure


### PR DESCRIPTION
## What I did 

- Major refactor to ensure that the merchants invoices show page was showing revenue and discounted revenue for that merchants items only
- Update model testing to ensure that all the new methods function as expected
- Minor refactor to the invoice_item model to leverage relationships and use less code in the queries
- Make sure that all tests are still passing and cover all edge cases
- Add fdiv to the unit price in the merchant invoices show table. All number add up correctly now
- Update views to render the revenue and discounted revenue that they should be rendering 
- did not change the admin view because it was not necessary